### PR TITLE
Ported the plugin to Python3, gedit 3.8/3.10.

### DIFF
--- a/tabs_extend.plugin
+++ b/tabs_extend.plugin
@@ -1,9 +1,9 @@
 [Plugin]
-Loader=python
+Loader=python3
 Module=tabs_extend
 IAge=3
 Name=Tabs Extend
 Description=Tabs extend options for gedit editor
 Authors=Éverton Ribeiro <nuxlli@gmail.com>
 Copyright=Copyright © 2008 Éverton Ribeiro <nuxlli@gmail.com>
-Website=http://code.google.com/p/gedit-tabsextend
+Website=https://github.com/nuxlli/gedit-tabsextend


### PR DESCRIPTION
Moved Close All/others to the File Menu for consistency.
Undo Close, Close All and Close others working. No translation provided.

Known issues:
The create_tab_from_location command can cause GTK criticals:
CRITICAL *_: gedit_multi_notebook_get_active_tab: assertion 'GEDIT_IS_MULTI_NOTEBOOK (mnb)' failed
Gtk-CRITICAL *_: gtk_action_group_get_action: assertion 'GTK_IS_ACTION_GROUP (action_group)' failed
Gtk-CRITICAL **: gtk_action_set_sensitive: assertion 'GTK_IS_ACTION (action)' failed
